### PR TITLE
Revert changes to migrate to cli v2

### DIFF
--- a/cmd/valiant/cmd.go
+++ b/cmd/valiant/cmd.go
@@ -12,7 +12,7 @@ func main() {
 	app.Name = "valiant"
 	app.Usage = "Validate request and responses to a web site."
 
-	app.Commands = []*cli.Command{
+	app.Commands = []cli.Command{
 		cmdExecute,
 		cmdUpdate,
 		cmdGenerate,

--- a/cmd/valiant/cmd_execute.go
+++ b/cmd/valiant/cmd_execute.go
@@ -4,16 +4,16 @@ import (
 	"github.com/urfave/cli"
 )
 
-var cmdExecute = &cli.Command{
+var cmdExecute = cli.Command{
 	Name:    "execute",
 	Aliases: []string{"e"},
 	Usage:   "execute tests against address",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
+		cli.StringFlag{
 			Name:  "address",
 			Usage: "HTTP address to upstream server to test (required)",
 		},
-		&cli.StringFlag{
+		cli.StringFlag{
 			Name:  "test-directory",
 			Value: "tests",
 			Usage: "Path to directory containing tests",

--- a/cmd/valiant/cmd_generate.go
+++ b/cmd/valiant/cmd_generate.go
@@ -7,12 +7,12 @@ import (
 	"github.com/urfave/cli"
 )
 
-var cmdGenerate = &cli.Command{
+var cmdGenerate = cli.Command{
 	Name:    "generate",
 	Aliases: []string{"g", "gen"},
 	Usage:   "generate example test file",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
+		cli.StringFlag{
 			Name:  "test-file",
 			Usage: "Full path to the destination, example: tests/00_example.yml (required)",
 		},

--- a/cmd/valiant/cmd_update.go
+++ b/cmd/valiant/cmd_update.go
@@ -7,16 +7,16 @@ import (
 	"github.com/urfave/cli"
 )
 
-var cmdUpdate = &cli.Command{
+var cmdUpdate = cli.Command{
 	Name:    "update",
 	Aliases: []string{"u"},
 	Usage:   "update test with upstream response",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
+		cli.StringFlag{
 			Name:  "address",
 			Usage: "HTTP address to upstream server to test (required)",
 		},
-		&cli.StringFlag{
+		cli.StringFlag{
 			Name:  "test-file",
 			Usage: "Full path to the test to update, example: tests/00_example.yml (required)",
 		},


### PR DESCRIPTION
This PR reverts the changes done for migrating to the cli's release 2.0. We have locked our version to `v1`